### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ services:
     restart: unless-stopped
 
   husky-site:
-    image: unplatform/husky-cms:latest
+    image: openlab/husky-cms:latest
     restart: unless-stopped
     ports:
       - 3000:3000


### PR DESCRIPTION
The version on Dockerhub at **unplatform/husky-cms** is at version 0.3.0, and needs to be updated or removed. Proposing to point new users at **openlab/husky-cms:latest** instead, as that seems to be up-to-date.